### PR TITLE
Fixed the namespace for OrderNotesAsset

### DIFF
--- a/src/assetbundles/ordernotes/OrderNotesAsset.php
+++ b/src/assetbundles/ordernotes/OrderNotesAsset.php
@@ -8,7 +8,7 @@
  * @copyright Copyright (c) 2018 Superbig
  */
 
-namespace superbig\ordernotes\assetbundles\OrderNotes;
+namespace superbig\ordernotes\assetbundles\ordernotes;
 
 use Craft;
 use craft\web\AssetBundle;

--- a/src/services/OrderNotesService.php
+++ b/src/services/OrderNotesService.php
@@ -12,7 +12,7 @@ namespace superbig\ordernotes\services;
 
 use craft\commerce\elements\Order;
 use craft\mail\Message;
-use superbig\ordernotes\assetbundles\OrderNotes\OrderNotesAsset;
+use superbig\ordernotes\assetbundles\ordernotes\OrderNotesAsset;
 use superbig\ordernotes\models\OrderNotesModel;
 use superbig\ordernotes\OrderNotes;
 


### PR DESCRIPTION
Composer 2 is going to be more strict about PSR-4 compliance, which means it will stop being case-insensitive when autoloading classes.